### PR TITLE
Use --cpu:wasm32 and support building with non-windows OSes

### DIFF
--- a/step1.nims
+++ b/step1.nims
@@ -4,12 +4,18 @@ if defined(emscripten):
   --nimcache:tmp # Store intermediate files close by in the ./tmp dir.
 
   --os:linux # Emscripten pretends to be linux.
-  --cpu:i386 # Emscripten is 32bits.
+  --cpu:wasm32 # Emscripten is 32bits.
   --cc:clang # Emscripten is very close to clang, so we ill replace it.
-  --clang.exe:emcc.bat  # Replace C
-  --clang.linkerexe:emcc.bat # Replace C linker
-  --clang.cpp.exe:emcc.bat # Replace C++
-  --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  when defined(windows):
+    --clang.exe:emcc.bat  # Replace C
+    --clang.linkerexe:emcc.bat # Replace C linker
+    --clang.cpp.exe:emcc.bat # Replace C++
+    --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  else:
+    --clang.exe:emcc  # Replace C
+    --clang.linkerexe:emcc # Replace C linker
+    --clang.cpp.exe:emcc # Replace C++
+    --clang.cpp.linkerexe:emcc # Replace C++ linker.
   --listCmd # List what commands we are running so that we can debug them.
 
   --gc:arc # GC:arc is friendlier with crazy platforms.

--- a/step2.nims
+++ b/step2.nims
@@ -4,12 +4,18 @@ if defined(emscripten):
   --nimcache:tmp # Store intermediate files close by in the ./tmp dir.
 
   --os:linux # Emscripten pretends to be linux.
-  --cpu:i386 # Emscripten is 32bits.
+  --cpu:wasm32 # Emscripten is 32bits.
   --cc:clang # Emscripten is very close to clang, so we ill replace it.
-  --clang.exe:emcc.bat  # Replace C
-  --clang.linkerexe:emcc.bat # Replace C linker
-  --clang.cpp.exe:emcc.bat # Replace C++
-  --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  when defined(windows):
+    --clang.exe:emcc.bat  # Replace C
+    --clang.linkerexe:emcc.bat # Replace C linker
+    --clang.cpp.exe:emcc.bat # Replace C++
+    --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  else:
+    --clang.exe:emcc  # Replace C
+    --clang.linkerexe:emcc # Replace C linker
+    --clang.cpp.exe:emcc # Replace C++
+    --clang.cpp.linkerexe:emcc # Replace C++ linker.
   --listCmd # List what commands we are running so that we can debug them.
 
   --gc:arc # GC:arc is friendlier with crazy platforms.

--- a/step3.nims
+++ b/step3.nims
@@ -4,12 +4,18 @@ if defined(emscripten):
   --nimcache:tmp # Store intermediate files close by in the ./tmp dir.
 
   --os:linux # Emscripten pretends to be linux.
-  --cpu:i386 # Emscripten is 32bits.
+  --cpu:wasm32 # Emscripten is 32bits.
   --cc:clang # Emscripten is very close to clang, so we ill replace it.
-  --clang.exe:emcc.bat  # Replace C
-  --clang.linkerexe:emcc.bat # Replace C linker
-  --clang.cpp.exe:emcc.bat # Replace C++
-  --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  when defined(windows):
+    --clang.exe:emcc.bat  # Replace C
+    --clang.linkerexe:emcc.bat # Replace C linker
+    --clang.cpp.exe:emcc.bat # Replace C++
+    --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  else:
+    --clang.exe:emcc  # Replace C
+    --clang.linkerexe:emcc # Replace C linker
+    --clang.cpp.exe:emcc # Replace C++
+    --clang.cpp.linkerexe:emcc # Replace C++ linker.
   --listCmd # List what commands we are running so that we can debug them.
 
   --gc:arc # GC:arc is friendlier with crazy platforms.

--- a/step4.nims
+++ b/step4.nims
@@ -4,12 +4,18 @@ if defined(emscripten):
   --nimcache:tmp # Store intermediate files close by in the ./tmp dir.
 
   --os:linux # Emscripten pretends to be linux.
-  --cpu:i386 # Emscripten is 32bits.
+  --cpu:wasm32 # Emscripten is 32bits.
   --cc:clang # Emscripten is very close to clang, so we ill replace it.
-  --clang.exe:emcc.bat  # Replace C
-  --clang.linkerexe:emcc.bat # Replace C linker
-  --clang.cpp.exe:emcc.bat # Replace C++
-  --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  when defined(windows):
+    --clang.exe:emcc.bat  # Replace C
+    --clang.linkerexe:emcc.bat # Replace C linker
+    --clang.cpp.exe:emcc.bat # Replace C++
+    --clang.cpp.linkerexe:emcc.bat # Replace C++ linker.
+  else:
+    --clang.exe:emcc  # Replace C
+    --clang.linkerexe:emcc # Replace C linker
+    --clang.cpp.exe:emcc # Replace C++
+    --clang.cpp.linkerexe:emcc # Replace C++ linker.
   --listCmd # List what commands we are running so that we can debug them.
 
   --gc:arc # GC:arc is friendlier with crazy platforms.


### PR DESCRIPTION
I found out from a [memory error](https://github.com/nim-lang/Nim/issues/17026) that wasm32 is a better cpu target for emscripten. I also added a branch for config options that are different on non-windows OSes.