### PR TITLE
fix/step3

### DIFF
--- a/step3.nim
+++ b/step3.nim
@@ -92,7 +92,7 @@ proc mainLoop() {.cdecl.} =
   mvp = m * p;
 
   glUseProgram(program)
-  var mvp_addr = cast[ptr GLFloat](addr mvp[0])
+  var mvp_addr = cast[ptr GLFloat](mvp.unsafeAddr)
   glUniformMatrix4fv(mvpLocation.GLint, 1, GL_FALSE, mvp_addr);
   glDrawArrays(GL_TRIANGLES, 0, 3);
 

--- a/step3.nim
+++ b/step3.nim
@@ -88,11 +88,12 @@ proc mainLoop() {.cdecl.} =
   glClear(GL_COLOR_BUFFER_BIT)
 
   m = rotateZ(getTime().float32)
-  p = ortho(-1, 1, 1, -1, -1000, 1000)
+  p = ortho[float32](-1, 1, 1, -1, -1000, 1000)
   mvp = m * p;
 
   glUseProgram(program)
-  glUniformMatrix4fv(mvpLocation.GLint, 1, GL_FALSE, addr mvp[0]);
+  var mvp_addr = cast[ptr GLFloat](addr mvp[0])
+  glUniformMatrix4fv(mvpLocation.GLint, 1, GL_FALSE, mvp_addr);
   glDrawArrays(GL_TRIANGLES, 0, 3);
 
   # Swap buffers (this will display the red color)

--- a/step3.nims
+++ b/step3.nims
@@ -21,7 +21,6 @@ if defined(emscripten):
   --gc:arc # GC:arc is friendlier with crazy platforms.
   --exceptions:goto # Goto exceptions are friendlier with crazy platforms.
   --define:noSignalHandler # Emscripten doesn't support signal handlers.
-  --define:vmathArrayBased # For interop with OpenGL
 
   # Pass this to Emscripten linker to generate html file scaffold for us.
   switch("passL", "-o step3.html --preload-file data --shell-file shell_minimal.html")

--- a/step3.nims
+++ b/step3.nims
@@ -21,6 +21,7 @@ if defined(emscripten):
   --gc:arc # GC:arc is friendlier with crazy platforms.
   --exceptions:goto # Goto exceptions are friendlier with crazy platforms.
   --define:noSignalHandler # Emscripten doesn't support signal handlers.
+  --define:vmathArrayBased # For interop with OpenGL
 
   # Pass this to Emscripten linker to generate html file scaffold for us.
   switch("passL", "-o step3.html --preload-file data --shell-file shell_minimal.html")


### PR DESCRIPTION
OS: Windows 10
Nim: 1.6.2

I was getting the following two errors for Step 3, which I was able to resolve with these changes.

* `ortho` seemed to be creating a GMat4[system.int] given the literals, so I just did `ortho[float32]()` instead.
* `addr mvp[0]` seemed to be confused getting a Vec4 instead of an `array`. I enabled the `-d:vmathArrayBased` define and then casted it to a `ptr GLFloat` which seems to solve the problem?

I'm out of my element but this worked for me!

### Error 1
```bash
step3.nim(91, 12) Error: type mismatch:
got 'GMat4[system.int]' for 'ortho(-1, 1, 1, -1, -1000, 1000)' but
expected 'Mat4 = GMat4[system.float32]'
```

### Error 2
```bash
step3.nim(95, 62) Error: expression has no address; maybe use 'unsafeAddr'
```