### PR TITLE
Add missing function in shell_minimal.html

### DIFF
--- a/shell_minimal.html
+++ b/shell_minimal.html
@@ -64,6 +64,14 @@
             console.log(text);
           }
         },
+        setCanvasSize: function(width, height) {
+          var canvas = document.getElementById('canvas');
+          if (canvas.width !== width || canvas.height !== height) {
+            canvas.width = width;
+            canvas.height = height;
+            Module.setStatus('Canvas size set to ' + width + 'x' + height);
+          }
+        },
         totalDependencies: 0,
         monitorRunDependencies: function(left) {
           this.totalDependencies = Math.max(this.totalDependencies, left);


### PR DESCRIPTION
Using shell_minimal.html would lead to errors because it uses `Module.setCanvasSize(w, h)` but it was never defined. While this wouldn't stop code from running, it would still produce errors.